### PR TITLE
Fix Tests for 2020

### DIFF
--- a/test/integration/workarea/storefront/place_order_integration_test.decorator
+++ b/test/integration/workarea/storefront/place_order_integration_test.decorator
@@ -7,7 +7,7 @@ module Workarea
           credit_card: {
             number: '2',
             month:  1,
-            year:   2020,
+            year:   next_year,
             cvv:    '999',
             stripe_token: '2'
           }

--- a/test/integration/workarea/storefront/users/credit_cards_integration_test.decorator
+++ b/test/integration/workarea/storefront/users/credit_cards_integration_test.decorator
@@ -19,7 +19,7 @@ module Workarea
       assert_equal('Ben', credit_card.first_name)
       assert_equal('Crouse', credit_card.last_name)
       assert_equal(1, credit_card.month)
-      assert_equal(2020, credit_card.year)
+      assert_equal(next_year, credit_card.year)
       assert(credit_card.token.present?)
     end
   end


### PR DESCRIPTION
Update all tests so that they no longer depend on the year 2020 as an
expiration year. Instead, use the  method provided by Workarea.

STRIPE-2